### PR TITLE
Remove deprecated Encoding key in desktop file

### DIFF
--- a/data/com.vinszent.GnomeTwitch.desktop.in
+++ b/data/com.vinszent.GnomeTwitch.desktop.in
@@ -11,4 +11,3 @@ Exec=gnome-twitch
 Icon=gnome-twitch
 Categories=GTK;GNOME;AudioVideo;Player;Video;
 Terminal=false
-Encoding=UTF-8


### PR DESCRIPTION
According to https://specifications.freedesktop.org/desktop-entry-spec/1.0/apc.html the Encoding key is deprecated.
All desktop files are now required to be encoded in UTF-8.