### PR TITLE
Replace unsafe format string by safe alternative

### DIFF
--- a/src/gt-twitch.c
+++ b/src/gt-twitch.c
@@ -1720,7 +1720,7 @@ gt_twitch_follows_all(GtTwitch* self, const gchar* user_name, GError** error)
             _("Twitch replied with error code '%d', message '%s' and body '%s'"),
             msg->status_code, msg->reason_phrase, msg->response_body->data);
 
-        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOWS_ALL, msg_str);
+        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOWS_ALL, "%s", msg_str);
 
         g_free(msg_str);
 
@@ -1864,7 +1864,7 @@ gt_twitch_follow_channel(GtTwitch* self,
             _("Twitch replied with error code '%d', message '%s' and body '%s'"),
             msg->status_code, msg->reason_phrase, msg->response_body->data);
 
-        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOW_CHANNEL, msg_str);
+        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOW_CHANNEL, "%s", msg_str);
 
         g_free(msg_str);
 
@@ -1942,7 +1942,7 @@ gt_twitch_unfollow_channel(GtTwitch* self,
             _("Twitch replied with error code '%d', message '%s' and body '%s'"),
             msg->status_code, msg->reason_phrase, msg->response_body->data);
 
-        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOW_CHANNEL, msg_str);
+        g_set_error(error, GT_TWITCH_ERROR, GT_TWITCH_ERROR_FOLLOW_CHANNEL, "%s", msg_str);
 
         g_free(msg_str);
 


### PR DESCRIPTION
Compiling with -Werror=format-security fails because a printf-like function was used in an unsafe way.
Format strings for functions like this should be string literals, to avoid injection of
format specifiers, which can lead to undefined behavior if they are not filled in with arguments.

If one wants to pass a normal string to one of those functions without formatting, the format string
"%s" should be used, with the desired string passed as an argument for it.

See also:
https://stackoverflow.com/questions/17260409/fprintf-error-format-not-a-string-literal-and-no-format-arguments-werror-for
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html