### PR TITLE
Fix spelling of log in

### DIFF
--- a/src/gt-chat.c
+++ b/src/gt-chat.c
@@ -619,7 +619,7 @@ after_connected_cb(GObject* source,
             gt_app_is_logged_in(main_app));
         gtk_entry_set_placeholder_text(GTK_ENTRY(priv->chat_entry),
             gt_app_is_logged_in(main_app)
-            ? _("Send a message") : _("Please login to chat"));
+            ? _("Send a message") : _("Please log in to chat"));
     }
 }
 


### PR DESCRIPTION
Since it's a verb, it is spelled "log in".
Otherwise it becomes a noun.