### PR TITLE
Use Unicode in translatable strings

### DIFF
--- a/data/com.vinszent.GnomeTwitch.appdata.xml.in
+++ b/data/com.vinszent.GnomeTwitch.appdata.xml.in
@@ -13,9 +13,9 @@
     </p>
     <p>Notable Features:</p>
     <ul>
-      <li>Watch your favourite streams natively with fully accelerated video</li>
+      <li>Watch your favorite streams natively with fully accelerated video</li>
       <li>Built in chat which can even be overlayed over the video</li>
-      <li>Easy favourites/follows management and receive notifications when they are online</li>
+      <li>Easy favorites/follows management and receive notifications when they are online</li>
     </ul>
   </description>
   <url type="homepage">http://gnome-twitch.vinszent.com/</url>
@@ -23,7 +23,7 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/vinszent/gnome-twitch/master/data/screenshots/scrot_player.png</image>
-      <caption>Watching a stream including chat</caption>
+      <caption>Watching a stream with a chat</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/vinszent/gnome-twitch/master/data/screenshots/scrot_streams.png</image>

--- a/data/com.vinszent.GnomeTwitch.gschema.xml
+++ b/data/com.vinszent.GnomeTwitch.gschema.xml
@@ -19,7 +19,7 @@
     <key name="volume" type="d">
       <range min="0.0" max="1.0"/>
       <default>0.3</default>
-      <summary>Current volume of player</summary>
+      <summary>Current volume of the player</summary>
     </key>
     <key name="window-height" type="i">
       <default>710</default>
@@ -36,8 +36,8 @@
       <summary>Twitch OAuth token</summary>
       <description>
         OAuth token used to authenticate all requests to the Twitch API.
-        Note that if you want to “logout” then you can just set the OAuth token
-        to an empty string
+        Note that if you want to “log out” then you can just set the OAuth
+        token to an empty string.
       </description>
     </key>
     <key name="user-name" type="s">
@@ -51,9 +51,9 @@
     </key>
     <key name="user-id" type="s">
       <default>''</default>
-      <summary>Twitch user id</summary>
+      <summary>Twitch user ID</summary>
       <description>
-        User id that is used in conjunction with the OAuth token
+        User ID that is used in conjunction with the OAuth token
         to authenticate to the Twitch API.
       </description>
     </key>

--- a/data/com.vinszent.GnomeTwitch.gschema.xml
+++ b/data/com.vinszent.GnomeTwitch.gschema.xml
@@ -36,7 +36,7 @@
       <summary>Twitch OAuth token</summary>
       <description>
         OAuth token used to authenticate all requests to the Twitch API.
-        Note that if you want to "logout" then you can just set the OAuth token
+        Note that if you want to “logout” then you can just set the OAuth token
         to an empty string
       </description>
     </key>

--- a/src/gt-app.c
+++ b/src/gt-app.c
@@ -268,7 +268,7 @@ open_channel_after_fetch_cb(GObject* source,
     }
     else if (!gt_channel_is_online(channel))
     {
-        gt_win_show_info_message(win, _("Unable to open channel %s because it's not online"),
+        gt_win_show_info_message(win, _("Unable to open channel %s because it’s not online"),
             gt_channel_get_name(channel));
     }
     else

--- a/src/gt-app.c
+++ b/src/gt-app.c
@@ -380,7 +380,7 @@ startup(GApplication* app)
     menu_bld = gtk_builder_new_from_resource("/com/vinszent/GnomeTwitch/ui/app-menu.ui");
     priv->app_menu = G_MENU_MODEL(gtk_builder_get_object(menu_bld, "app_menu"));
     g_object_ref(priv->app_menu);
-    priv->login_item = g_menu_item_new(_("Login to Twitch"), "win.show_twitch_login");
+    priv->login_item = g_menu_item_new(_("Log in to Twitch"), "win.show_twitch_login");
     g_menu_prepend_item(G_MENU(priv->app_menu), priv->login_item);
 
     gtk_application_set_app_menu(GTK_APPLICATION(app), G_MENU_MODEL(priv->app_menu));

--- a/src/gt-game.c
+++ b/src/gt-game.c
@@ -162,7 +162,7 @@ update_from_data(GtGame* self, GtGameData* data)
             if (GT_IS_WIN(win))
             {
                 /* Translators: %s will be filled with the game name */
-                gt_win_show_error_message(win, _("Unable to update game '%s'"),
+                gt_win_show_error_message(win, _("Unable to update game “%s”"),
                     "Unable to update game with id '%s' and name '%s' because: "
                     "New data with id '%s' does not match the current one",
                     old_data->id, old_data->name, data->id);

--- a/src/gt-player.c
+++ b/src/gt-player.c
@@ -883,7 +883,7 @@ streams_list_cb(GObject* source,
         if (g_error_matches(err, GT_TWITCH_ERROR, GT_TWITCH_ERROR_SOUP_NOT_FOUND))
         {
             /* Translators: %s will be filled with the channel name */
-            gt_win_show_info_message(win, _("Unable to open channel %s because it's offline"),
+            gt_win_show_info_message(win, _("Unable to open channel %s because it’s offline"),
                 gt_channel_get_name(priv->channel));
         }
         else

--- a/src/gt-twitch-login-dlg.c
+++ b/src/gt-twitch-login-dlg.c
@@ -45,7 +45,7 @@ gt_twitch_login_dlg_new(GtkWindow* parent)
     return g_object_new(GT_TYPE_TWITCH_LOGIN_DLG,
                         "transient-for", parent,
                         "use-header-bar", 1,
-                        "title", _("Login to Twitch"),
+                        "title", _("Log in to Twitch"),
                         NULL);
 }
 

--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -701,7 +701,7 @@ gt_win_open_channel(GtWin* self, GtChannel* chan)
     }
     else
     {
-        gt_win_show_info_message(self, _("Unable to open channel %s because it's not online"),
+        gt_win_show_info_message(self, _("Unable to open channel %s because it’s not online"),
             gt_channel_get_name(chan));
 
         gtk_stack_set_visible_child_name(GTK_STACK(priv->main_stack),


### PR DESCRIPTION
See https://developer.gnome.org/hig/stable/typography.html. Plus some improvements to translatable strings. Probably post-0.4.1 material. :)