### PR TITLE
Make gnome-twitch ready for gobject-introspection

### DIFF
--- a/include/gnome-twitch/gt-player-backend.h
+++ b/include/gnome-twitch/gt-player-backend.h
@@ -34,6 +34,13 @@ struct _GtPlayerBackendInterface
     GtkWidget* (*get_widget) (GtPlayerBackend* backend);
 };
 
+/**
+ * gt_player_backend_get_widget
+ *
+ * Returns: (transfer none): The Gtk Widget
+ *
+ * Returns a Gtk.Widget that presents the player to the user
+ */
 GtkWidget* gt_player_backend_get_widget(GtPlayerBackend* backend);
 
 G_END_DECLS

--- a/include/gnome-twitch/gt-player-backend.h
+++ b/include/gnome-twitch/gt-player-backend.h
@@ -25,7 +25,7 @@ G_BEGIN_DECLS
 
 #define GT_TYPE_PLAYER_BACKEND (gt_player_backend_get_type())
 
-G_DECLARE_INTERFACE(GtPlayerBackend, gt_player_backend, GT, PLAYER_BACKEND, GObject);
+G_DECLARE_INTERFACE(GtPlayerBackend, gt_player_backend, GT, PLAYER_BACKEND, GObject)
 
 struct _GtPlayerBackendInterface
 {

--- a/src/gt-app.c
+++ b/src/gt-app.c
@@ -507,6 +507,7 @@ gt_app_init(GtApp* self)
 
     self->settings = g_settings_new("com.vinszent.GnomeTwitch");
     self->players_engine = peas_engine_get_default();
+    peas_engine_enable_loader(self->players_engine, "python3");
     self->soup = soup_session_new();
 
     gchar* plugin_dir;

--- a/src/gt-resource-downloader.c
+++ b/src/gt-resource-downloader.c
@@ -370,7 +370,7 @@ void
 gt_resource_downloader_set_image_filetype(GtResourceDownloader* self, const gchar* image_filetype)
 {
     RETURN_IF_FAIL(GT_IS_RESOURCE_DOWNLOADER(self));
-    RETURN_IF_FAIL(!utils_str_empty(image_filetype))
+    RETURN_IF_FAIL(!utils_str_empty(image_filetype));
 
     GtResourceDownloaderPrivate* priv = gt_resource_downloader_get_instance_private(self);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -110,33 +110,30 @@ gt_library_c_args = gt_executable_c_args
 
 if host_machine.system() == 'windows'
   gt_executable_link_args += '-mwindows'
+endif
 
   # We need to do this because Windows doesn't allow DLLs to be linked
   # with undefined references. Therefore we move all shared functionality into a
   # sub-library that plugins can be linked against.
-  gt_library = shared_library('gnome-twitch', src_gt_library,
-    include_directories : include_dir,
-    dependencies : deps_gt_library,
-    install : true,
-    c_args : gt_library_c_args)
+gt_library = shared_library('gnome-twitch', src_gt_library,
+  include_directories : include_dir,
+  dependencies : deps_gt_library,
+  install : true,
+  c_args : gt_library_c_args)
 
-  gt_library_dep = declare_dependency(
-    include_directories : include_dir,
-    link_with : gt_library)
+gt_library_dep = declare_dependency(
+  include_directories : include_dir,
+  link_with : gt_library)
 
-  pkg.generate(
-    libraries : gt_library,
-    name : 'gnome-twitch',
-    description : 'Library used for building GNOME Twitch plugins',
-    requires : ['gtk+-3.0', 'libpeas-1.0'],
-    version : meson.project_version())
+pkg.generate(
+  libraries : gt_library,
+  name : 'gnome-twitch',
+  description : 'Library used for building GNOME Twitch plugins',
+  requires : ['gtk+-3.0', 'libpeas-1.0'],
+  install : true,
+  version : meson.project_version())
 
-  deps_gt += gt_library_dep
-else
-  # Otherwise we can just compile shared functionality
-  # straight into the main executable
-  src_gt_executable += src_gt_library
-endif
+deps_gt += gt_library_dep
 
 executable('gnome-twitch', src_gt_executable,
   include_directories : include_dir,

--- a/src/meson.build
+++ b/src/meson.build
@@ -140,7 +140,7 @@ gnome.generate_gir(gt_library,
   nsversion: api,
   namespace: 'Gt',
   dependencies: deps_gt_library,
-  extra_args: ['--include','Gtk-3.0'],
+  includes: ['Gtk-3.0'],
   install: true,
   install_dir_gir: get_option('datadir') + '/gir-1.0',
   install_dir_typelib: get_option('libdir') + '/girepository-1.0'

--- a/src/meson.build
+++ b/src/meson.build
@@ -108,6 +108,8 @@ gt_executable_link_args = []
 
 gt_library_c_args = gt_executable_c_args
 
+api = '0.2'
+
 if host_machine.system() == 'windows'
   gt_executable_link_args += '-mwindows'
 endif
@@ -115,7 +117,7 @@ endif
   # We need to do this because Windows doesn't allow DLLs to be linked
   # with undefined references. Therefore we move all shared functionality into a
   # sub-library that plugins can be linked against.
-gt_library = shared_library('gnome-twitch', src_gt_library,
+gt_library = shared_library('gnome-twitch-' + api, src_gt_library,
   include_directories : include_dir,
   dependencies : deps_gt_library,
   install : true,
@@ -127,11 +129,21 @@ gt_library_dep = declare_dependency(
 
 pkg.generate(
   libraries : gt_library,
-  name : 'gnome-twitch',
+  name : 'gnome-twitch-' + api,
   description : 'Library used for building GNOME Twitch plugins',
   requires : ['gtk+-3.0', 'libpeas-1.0'],
   install : true,
   version : meson.project_version())
+
+gnome.generate_gir(gt_library,
+            sources: [meson.current_source_dir()+'/../include/gnome-twitch/gt-player-backend.h'],
+            nsversion: api,
+            namespace: 'Gt',
+            dependencies: deps_gt_library,
+            install: true,
+            install_dir_gir: get_option('datadir') + '/gir-1.0',
+            install_dir_typelib: get_option('libdir') + '/girepository-1.0'
+)
 
 deps_gt += gt_library_dep
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -136,14 +136,14 @@ pkg.generate(
   version : meson.project_version())
 
 gnome.generate_gir(gt_library,
-  sources: ['../include/gnome-twitch/gt-player-backend.h'],
+  sources: [join_paths('..', 'include', 'gnome-twitch', 'gt-player-backend.h')],
   nsversion: api,
   namespace: 'Gt',
   dependencies: deps_gt_library,
   includes: ['Gtk-3.0'],
   install: true,
-  install_dir_gir: get_option('datadir') + '/gir-1.0',
-  install_dir_typelib: get_option('libdir') + '/girepository-1.0'
+  install_dir_gir: join_paths(get_option('datadir'), 'gir-1.0'),
+  install_dir_typelib: join_paths(get_option('libdir'), '/girepository-1.0')
 )
 
 deps_gt += gt_library_dep

--- a/src/meson.build
+++ b/src/meson.build
@@ -136,13 +136,14 @@ pkg.generate(
   version : meson.project_version())
 
 gnome.generate_gir(gt_library,
-            sources: [meson.current_source_dir()+'/../include/gnome-twitch/gt-player-backend.h'],
-            nsversion: api,
-            namespace: 'Gt',
-            dependencies: deps_gt_library,
-            install: true,
-            install_dir_gir: get_option('datadir') + '/gir-1.0',
-            install_dir_typelib: get_option('libdir') + '/girepository-1.0'
+  sources: ['../include/gnome-twitch/gt-player-backend.h'],
+  nsversion: api,
+  namespace: 'Gt',
+  dependencies: deps_gt_library,
+  extra_args: ['--include','Gtk-3.0'],
+  install: true,
+  install_dir_gir: get_option('datadir') + '/gir-1.0',
+  install_dir_typelib: get_option('libdir') + '/girepository-1.0'
 )
 
 deps_gt += gt_library_dep

--- a/src/meson.build
+++ b/src/meson.build
@@ -143,7 +143,7 @@ gnome.generate_gir(gt_library,
   includes: ['Gtk-3.0'],
   install: true,
   install_dir_gir: join_paths(get_option('datadir'), 'gir-1.0'),
-  install_dir_typelib: join_paths(get_option('libdir'), '/girepository-1.0')
+  install_dir_typelib: join_paths(get_option('libdir'), 'girepository-1.0')
 )
 
 deps_gt += gt_library_dep


### PR DESCRIPTION
I did a bunch of things in order to make it possible to write player-backends in other languages than C and make full-fledged use of GObject Introspection.