### PR TITLE
Adjust to new AppStream metadata path

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -32,7 +32,7 @@ if (host_machine.system() != 'windows')
     output : 'com.vinszent.GnomeTwitch.appdata.xml',
     po_dir : '../po',
     install : true,
-    install_dir : join_paths(datadir, 'appdata'))
+    install_dir : join_paths(datadir, 'metainfo'))
 endif
 
 icondir = join_paths(datadir, 'icons', 'hicolor')


### PR DESCRIPTION
The path where AppStream metadata is stored has changed. The old path is still supported as a legacy path, but using the new path is advised. See section 2.1.2 in https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent