### PR TITLE
enable mpv's automatic hardware decoder detection

### DIFF
--- a/player-backends/player-backend-mpv-opengl/gt-player-backend-mpv-opengl.c
+++ b/player-backends/player-backend-mpv-opengl/gt-player-backend-mpv-opengl.c
@@ -598,6 +598,7 @@ gt_player_backend_mpv_opengl_init(GtPlayerBackendMpvOpenGL* self)
     check_mpv_error(mpv_set_option_string(priv->mpv, "audio-client-name", "GNOME Twitch"));
     check_mpv_error(mpv_set_option_string(priv->mpv, "title", ""));
     check_mpv_error(mpv_set_option_string(priv->mpv, "vo", "opengl-cb"));
+    check_mpv_error(mpv_set_option_string(priv->mpv, "hwdec", "auto"));
     check_mpv_error(mpv_set_option_string(priv->mpv, "softvol", "yes"));
     check_mpv_error(mpv_set_option_string(priv->mpv, "softvol-max", "100"));
     check_mpv_error(mpv_observe_property(priv->mpv, 0, "volume", MPV_FORMAT_DOUBLE));


### PR DESCRIPTION
I just added the automatic detection by mpv and the CPU usage went down from 90% to like 10%. The mpv documentation says that it will try vaapi, vdpau and then fall back to software rendering.